### PR TITLE
fixed reference to build

### DIFF
--- a/.github/workflows/minification.yml
+++ b/.github/workflows/minification.yml
@@ -34,8 +34,6 @@ jobs:
         
     - name: add minfied files to build directory
       run: |
-        rm -r build/*
-        rmdir build
         mkdir build
         cp -a minified/. build
         


### PR DESCRIPTION
Deleted the build directory but forgot to remove the reference to the build directory in the workflow.